### PR TITLE
Fail gracefully if Pyckles is not properly installed.

### DIFF
--- a/pyckles/__init__.py
+++ b/pyckles/__init__.py
@@ -3,4 +3,7 @@ from .spectral_library import SpectralLibrary
 
 from importlib import metadata
 
-__version__ = metadata.version(__package__)
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    __version__ = "undetermined"


### PR DESCRIPTION
Adding this try-except block around metadata so it is possible to just set the PYTHONPATH to the Pyckles directory. ScopeSim has the same guard.