### PR TITLE
Allow numpy 2.x, keep 1.26.4 in the lock file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1688,4 +1688,4 @@ syn = ["synphot"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "93cff9bc94b4d38f704a0f0b1f6bf72ab1ccb75f7401c3cf91db2e4e4855fbaf"
+content-hash = "b9a2c2adf4f726253e07d993c9e16801ac833dfdd49eac6896103ea475443a8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ documentation = "https://pyckles.readthedocs.io/"
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.5"
 pytest-cov = "^6.0.0"
-numpy = ">=1.26.4, <2.0.0"
+numpy = ">=1.26.4, <2.3.0"
 
 [tool.poetry.group.docs]
 optional = true
@@ -44,7 +44,7 @@ optional = true
 sphinx = ">=5.3, <8.0"
 sphinx-book-theme = "^1.1.0"
 sphinxcontrib-apidoc = ">=0.4, <0.6"
-numpy = ">=1.26.4, <2.0.0"
+numpy = ">=1.26.4, <2.3.0"
 numpydoc = "^1.6.0"
 matplotlib = "^3.10.1"
 


### PR DESCRIPTION
[b5701b4](https://github.com/AstarVienna/Pyckles/commit/b5701b4ba9f30c123c7dcc20ed0f0ab7c4ce71dd) was accidentally pushed to `main` (meaning our branch protection needs updating here) and should have been part of this PR instead, but I'm just gonna leave it like that now, this repo isn't critical anyway...